### PR TITLE
Separate faq listing with commas

### DIFF
--- a/commanderbot/ext/faq/faq_guild_state.py
+++ b/commanderbot/ext/faq/faq_guild_state.py
@@ -123,7 +123,7 @@ class FaqGuildState(CogGuildState):
     async def list_faqs(self, ctx: GuildContext):
         if faqs := await self.store.get_all_faqs(self.guild):
             sorted_faqs = sorted(faqs, key=lambda faq: faq.key)
-            keys = " ".join(f"`{faq.key}`" for faq in sorted_faqs)
+            keys = ", ".join(f"`{faq.key}`" for faq in sorted_faqs)
             count = len(sorted_faqs)
             header = f"There are {count} FAQs available:"
             content = f"{header} {keys}"


### PR DESCRIPTION
Quick fix but significantly improves readability

Before:
![image](https://user-images.githubusercontent.com/30565442/176541895-566f5fcb-d61b-4be8-ab20-6f43daf1de27.png)

After:
![image](https://user-images.githubusercontent.com/30565442/176541917-a1d00e6b-89eb-4766-89e7-6a355bbe8819.png)
