### PR TITLE
Updated Jira cog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Added a config option for `mccq` to allow certain users to run the reload command
+- Added a link button under `jira` issue embeds
 
 ### Changed
 
 - Adjusted the format of the presence status set by `mccq`
+- Querying `jira` issues using a URL as the argument will now ignore the base URL stored in the `jira` cog and instead get it from the argument
 
 ## [0.19.0] - 2022-08-27
 

--- a/commanderbot/ext/jira/jira_client.py
+++ b/commanderbot/ext/jira/jira_client.py
@@ -6,8 +6,8 @@ import aiohttp
 from commanderbot.ext.jira.jira_issue import JiraIssue, StatusColor
 from commanderbot.lib.responsive_exception import ResponsiveException
 
-JIRA_URL_PATTERN = re.compile(r"^(https?://[^/]+).*?(\w+)\-(\d+)")
-JIRA_ISSUE_ID_PATTERN = re.compile(r"^(\w+)\-(\d+)")
+JIRA_URL_PATTERN = re.compile(r"^(https?://[^/]+).*?(\w+)-(\d+)")
+JIRA_ISSUE_ID_PATTERN = re.compile(r"^(\w+)-(\d+)")
 
 
 class JiraException(ResponsiveException):

--- a/commanderbot/ext/jira/jira_client.py
+++ b/commanderbot/ext/jira/jira_client.py
@@ -64,7 +64,7 @@ class JiraClient:
             raise RequestError(issue_id)
 
     async def get_issue(self, issue: str) -> JiraIssue:
-        # Extract the issue ID and base URL or throw an
+        # Extract the issue ID parts and base URL or throw an
         # exception if the regex matches fail
         unfiltered_url: str = issue.split("?")[0]
         base_url: str = self.url
@@ -77,7 +77,7 @@ class JiraClient:
         else:
             raise InvalidIssueFormat
 
-        # Format issue ID
+        # Create issue ID
         issue_id = "-".join((project.upper(), str(int(id))))
 
         # Request issue data and get its fields


### PR DESCRIPTION
### Added
- Added a link button under Jira issue embeds

### Changed
- Querying Jira issues using a URL as the argument will now ignore the base URL stored in the Jira cog and instead get it from the argument